### PR TITLE
feat(client): add WithGRPCDialOptions for custom gRPC dial options

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -61,7 +61,7 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) buildDialOptions() []grpc.DialOption {
-	var opts []grpc.DialOption
+	opts := append([]grpc.DialOption{}, c.config.GRPCDialOptions...)
 
 	if c.config.TLS != nil {
 		tlsConfig := c.buildTLSConfig()

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/noders-team/go-daml/pkg/auth"
+	"google.golang.org/grpc"
 )
 
 type Config struct {
@@ -9,6 +10,7 @@ type Config struct {
 	AdminAddress string
 	TLS          *TLSConfig
 	Auth         *AuthConfig
+	GRPCDialOptions []grpc.DialOption
 }
 
 type TLSConfig struct {
@@ -57,6 +59,12 @@ func WithTokenProvider(provider auth.TokenProvider) ConfigOption {
 			c.Auth = &AuthConfig{}
 		}
 		c.Auth.TokenProvider = provider
+	}
+}
+
+func WithGRPCDialOptions(opts ...grpc.DialOption) ConfigOption {
+	return func(c *Config) {
+		c.GRPCDialOptions = append(c.GRPCDialOptions, opts...)
 	}
 }
 


### PR DESCRIPTION
Add support for passing custom gRPC dial options to the client configuration. This allows users to set options like grpc.WithAuthority() for custom routing, additional interceptors, or other dial options.