### PR TITLE
fix(codegen): handle interned LF v2 type applications

### DIFF
--- a/internal/codegen/astgen/v3/common.go
+++ b/internal/codegen/astgen/v3/common.go
@@ -482,9 +482,13 @@ func (c *codeGenAst) extractType(pkg *daml.Package, typ *daml.Type) string {
 			fieldType = c.handleConType(pkg, isConType)
 		} else if builtinType := prim.GetBuiltin(); builtinType != nil {
 			fieldType = c.handleBuiltinType(pkg, builtinType)
+		} else if _, isTypeApp := prim.Sum.(*daml.Type_Tapp); isTypeApp {
+			fieldType = c.extractType(pkg, prim)
 		} else {
 			fieldType = prim.String()
 		}
+	case *daml.Type_Tapp:
+		fieldType = c.handleTypeApp(pkg, v.Tapp)
 	case *daml.Type_Con_:
 		fieldType = c.handleConType(pkg, v.Con)
 	case *daml.Type_Var_:
@@ -504,6 +508,30 @@ func (c *codeGenAst) extractType(pkg *daml.Package, typ *daml.Type) string {
 	}
 
 	return model.NormalizeDAMLType(fieldType)
+}
+
+func (c *codeGenAst) handleTypeApp(pkg *daml.Package, typeApp *daml.Type_TApp) string {
+	if typeApp == nil {
+		return "unknown_type_app"
+	}
+
+	lhsType := model.NormalizeDAMLType(c.extractType(pkg, typeApp.Lhs))
+	rhsType := model.NormalizeDAMLType(c.extractType(pkg, typeApp.Rhs))
+
+	switch lhsType {
+	case RawTypeOptional:
+		return "*" + rhsType
+	case RawTypeList:
+		return "[]" + rhsType
+	case RawTypeContractID:
+		return RawTypeContractID
+	case "TEXTMAP":
+		return "TEXTMAP"
+	case "GENMAP":
+		return "GENMAP"
+	default:
+		return rhsType
+	}
 }
 
 func (c *codeGenAst) handleBuiltinType(pkg *daml.Package, builtinType *daml.Type_Builtin) string {
@@ -591,47 +619,8 @@ func (c *codeGenAst) extractField(pkg *daml.Package, field *daml.FieldWithType) 
 		return fieldName, "", fmt.Errorf("field type is nil")
 	}
 
-	//	*Type_Var_
-	//	*Type_Con_
-	//	*Type_Syn_
-	//	*Type_Interned
-	var fieldType string
-	switch v := field.Type.Sum.(type) {
-	case *daml.Type_InternedType:
-		prim := pkg.InternedTypes[v.InternedType]
-		if prim != nil {
-			isConType := prim.GetCon()
-			if isConType != nil {
-				fieldType = c.handleConType(pkg, isConType)
-			} else if builtinType := prim.GetBuiltin(); builtinType != nil {
-				fieldType = c.handleBuiltinType(pkg, builtinType)
-			} else {
-				fieldType = prim.String()
-			}
-		} else {
-			fieldType = "complex_interned_type"
-		}
-	case *daml.Type_Con_:
-		fieldType = c.handleConType(pkg, v.Con)
-	case *daml.Type_Var_:
-		switch {
-		case v.Var.GetVarInternedStr() != 0:
-			// For variables, we use the interned string directly, not getName which expects DottedName
-			if int(v.Var.GetVarInternedStr()) < len(pkg.InternedStrings) {
-				fieldType = pkg.InternedStrings[v.Var.GetVarInternedStr()]
-			} else {
-				fieldType = "unknown_var"
-			}
-		default:
-			fieldType = "unnamed_var"
-		}
-	case *daml.Type_Syn_:
-		if v.Syn.Tysyn != nil {
-			fieldType = fmt.Sprintf("syn_%s", c.getName(pkg, v.Syn.Tysyn.GetNameInternedDname()))
-		} else {
-			fieldType = "syn_without_name"
-		}
-	default:
+	fieldType := c.extractType(pkg, field.Type)
+	if fieldType == "" {
 		return fieldName, "", fmt.Errorf("unsupported type sum: %T", field.Type.Sum)
 	}
 

--- a/internal/codegen/astgen/v3/common_test.go
+++ b/internal/codegen/astgen/v3/common_test.go
@@ -7,6 +7,128 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractFieldWithInternedTypeApplicationsV3(t *testing.T) {
+	codeGen := &codeGenAst{}
+
+	pkg := &daml.Package{
+		InternedStrings: []string{
+			"",
+			"optionalTsField",
+			"listTextField",
+			"contractIdField",
+			"Tenant",
+		},
+		InternedTypes: []*daml.Type{
+			{
+				Sum: &daml.Type_Builtin_{
+					Builtin: &daml.Type_Builtin{Builtin: daml.BuiltinType_OPTIONAL},
+				},
+			},
+			{
+				Sum: &daml.Type_Builtin_{
+					Builtin: &daml.Type_Builtin{Builtin: daml.BuiltinType_TIMESTAMP},
+				},
+			},
+			{
+				Sum: &daml.Type_Tapp{
+					Tapp: &daml.Type_TApp{
+						Lhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 0}},
+						Rhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 1}},
+					},
+				},
+			},
+			{
+				Sum: &daml.Type_Builtin_{
+					Builtin: &daml.Type_Builtin{Builtin: daml.BuiltinType_LIST},
+				},
+			},
+			{
+				Sum: &daml.Type_Builtin_{
+					Builtin: &daml.Type_Builtin{Builtin: daml.BuiltinType_TEXT},
+				},
+			},
+			{
+				Sum: &daml.Type_Tapp{
+					Tapp: &daml.Type_TApp{
+						Lhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 3}},
+						Rhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 4}},
+					},
+				},
+			},
+			{
+				Sum: &daml.Type_Builtin_{
+					Builtin: &daml.Type_Builtin{Builtin: daml.BuiltinType_CONTRACT_ID},
+				},
+			},
+			{
+				Sum: &daml.Type_Con_{
+					Con: &daml.Type_Con{
+						Tycon: &daml.TypeConId{
+							NameInternedDname: 1,
+						},
+					},
+				},
+			},
+			{
+				Sum: &daml.Type_Tapp{
+					Tapp: &daml.Type_TApp{
+						Lhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 6}},
+						Rhs: &daml.Type{Sum: &daml.Type_InternedType{InternedType: 7}},
+					},
+				},
+			},
+		},
+		InternedDottedNames: []*daml.InternedDottedName{
+			nil,
+			{SegmentsInternedStr: []int32{4}},
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		fieldNameIdx int32
+		typeIdx      int32
+		expectedName string
+		expectedType string
+	}{
+		{
+			name:         "optional timestamp from interned type app",
+			fieldNameIdx: 1,
+			typeIdx:      2,
+			expectedName: "optionalTsField",
+			expectedType: "*TIMESTAMP",
+		},
+		{
+			name:         "list text from interned type app",
+			fieldNameIdx: 2,
+			typeIdx:      5,
+			expectedName: "listTextField",
+			expectedType: "[]TEXT",
+		},
+		{
+			name:         "contract id from interned type app",
+			fieldNameIdx: 3,
+			typeIdx:      8,
+			expectedName: "contractIdField",
+			expectedType: "CONTRACT_ID",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			field := &daml.FieldWithType{
+				FieldInternedStr: tc.fieldNameIdx,
+				Type:             &daml.Type{Sum: &daml.Type_InternedType{InternedType: tc.typeIdx}},
+			}
+
+			fieldName, fieldType, err := codeGen.extractField(pkg, field)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedName, fieldName)
+			require.Equal(t, tc.expectedType, fieldType)
+		})
+	}
+}
+
 func TestParseKeyExpressionV3(t *testing.T) {
 	codeGen := &codeGenAst{}
 


### PR DESCRIPTION
## Summary
- handle interned `Type_Tapp` nodes in the v3 AST generator instead of stringifying the proto node
- route `extractField` through `extractType` so field decoding uses the same recursive logic
- add regression tests for interned `OPTIONAL`, `LIST`, and `CONTRACT_ID` type applications

## Problem
Current `go-daml` codegen fails on LF v2 interned type applications used by real DAML DARs, emitting invalid Go fragments like `tapp:{lhs:{internedtype:5} rhs:{internedtype:10}}` instead of valid types.

## Verification
```bash
go test ./internal/codegen/...
```