### PR TITLE
codegen: resolve NUMERIC/BIGNUMERIC in Daml-LF 2 type applications

### DIFF
--- a/internal/codegen/astgen/v3/common.go
+++ b/internal/codegen/astgen/v3/common.go
@@ -21,6 +21,8 @@ const (
 	RawTypeEnum       = "Enum"
 	RawTypeContractID = "CONTRACT_ID"
 	RawTypeList       = "LIST"
+	RawTypeNumeric    = "NUMERIC"
+	RawTypeBigNumeric = "BIGNUMERIC"
 )
 
 type codeGenAst struct {
@@ -536,6 +538,10 @@ func (c *codeGenAst) handleTypeApp(pkg *daml.Package, typeApp *daml.Type_TApp) s
 		return "TEXTMAP"
 	case "GENMAP":
 		return "GENMAP"
+	case RawTypeNumeric:
+		return RawTypeNumeric
+	case RawTypeBigNumeric:
+		return RawTypeBigNumeric
 	default:
 		return rhsType
 	}


### PR DESCRIPTION
Code generation fails for any model containing a `Decimal` field when the DAR is built with a Daml 3.x SDK.

## Symptom

```
Error: failed to generate Go code: generated.go:413:22: expected ';', found ':' (and 10 more errors)
```

The generated file contains `nat:10` where a type is expected.

## Cause

Daml-LF 2 encodes `Decimal` as `Numeric 10`: a type application whose left-hand side is `NUMERIC` and whose right-hand side is the scale, a Nat literal rather than a type.

`internal/codegen/astgen/v3/common.go::handleTypeApp` switches on the resolved left-hand type and has cases for `OPTIONAL`, `LIST`, `CONTRACT_ID`, `TEXTMAP` and `GENMAP`. `NUMERIC` has no case, so control reaches `default: return rhsType`, which returns the unresolved scale parameter. `handleBuiltinType` already resolves `NUMERIC` correctly on its own; the left-hand result is simply discarded here.

Every `Decimal` field in a model is affected, not a particular one.

The Daml-LF 1 path is unaffected, because it does not represent `Numeric` as a type application. This is why DARs built with SDK 2.x have never triggered it.

## Change

One case added for `NUMERIC` and one for `BIGNUMERIC`, returning the resolved left-hand type, consistent with the surrounding cases. Both names already exist in `model.primTypes`.

## Verification

Reproduced against a DAR built with SDK 3.4.11 containing seven `Decimal` fields across five templates and two interfaces. Before the change, generation fails with the error above. After it, generation succeeds and the resulting package compiles: fields are emitted as `NUMERIC`, and `go build ./...` on the consuming module is clean.